### PR TITLE
fix parsing long expressions

### DIFF
--- a/LaTeX-for-Gmail
+++ b/LaTeX-for-Gmail
@@ -5,7 +5,7 @@
 // @grant       GM_registerMenuCommand
 // @grant       GM_addElement
 // @require     https://cdn.jsdelivr.net/npm/katex@0.16.11/dist/katex.min.js
-// @version     3.9
+// @version     3.9.1
 // @author      Logan J. Fisher & GTK & MistralMireille
 // @description Adds a button to Gmail which toggles LaTeX rendering using traditional LaTeX and TeXTheWorld delimiters
 // @noframes
@@ -36,6 +36,7 @@ function renderLatex(html) {
         [INLINE_REGEX, false],
     ];
 
+    html = html.replaceAll('<wbr>', ''); // fixes parsing of long expressions (GMAIL inserts <wbr> tags for some reason)
     const div = document.createElement('div');
     katexReplaceList.forEach( ([regex, display]) => {
         html = html.replace(regex, (m, p1, p2) => {

--- a/LaTeX-for-Gmail
+++ b/LaTeX-for-Gmail
@@ -26,7 +26,7 @@ function buildRegex(delims) {
     const start = delims.map( d => escape(d.split('...')[0].trim()) );
     const end = delims.map( d => escape(d.split('...')[1].trim()) );
 
-    return new RegExp(`(${start.join('|')})(.+?)(${end.join('|')})`, 'g');
+    return new RegExp(`(${start.join('|')})(.+?)(${end.join('|')})`, 'gs');
 }
 
 


### PR DESCRIPTION
Issue previously affecting `\begin{equation}` & `\begin{displaymath}`.

Fixed by removing `<wbr>` tags  that Gmail sometimes inserts in the middle of long lines.